### PR TITLE
make sure that session[:morphed_from] remains the original user

### DIFF
--- a/app/controllers/morphing/morphing_controller.rb
+++ b/app/controllers/morphing/morphing_controller.rb
@@ -2,7 +2,7 @@ module Morphing
   class MorphingController < ApplicationController
     def morph
       morph_to = User.find(params[:id])
-      session[:morphed_from]  = current_user.id
+      session[:morphed_from] ||= current_user.id
       sign_in(:user, morph_to)
 
       flash[:success] = "Morphed into #{morph_to.name}"


### PR DESCRIPTION
Currently, if U1 morphs into U2 and then into U3, when they try to unmorph, they'll go from U3 to U2, but can't go back to their original user account without logging out and in. This PR only sets the `:morphed_from` session key the first time to prevent this, so `:morphed_from` will always be the original  user.