### PR TITLE
update nokogiri to 1.8.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       rails (>= 4.1.6)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     actionmailer (4.2.7.1)
       actionpack (= 4.2.7.1)
@@ -66,10 +66,10 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.1)
-    nokogiri (1.7.0.1)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.8.3)
+      mini_portile2 (~> 2.3.0)
     orm_adapter (0.5.0)
     rack (1.6.5)
     rack-test (0.6.3)


### PR DESCRIPTION
Update `nokogiri` to 1.8.3 due to a security vulnerability.  